### PR TITLE
popup content

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -32,6 +32,10 @@ body {
   --aug-border-bg: linear-gradient(to bottom right, teal, #00b4d8);
 }
 
+.popup-container-extended .popup-window {
+  overflow-y: auto;
+}
+
 .loading-text::after {
   content: "";
   animation: loadingDots 1s steps(4, end) infinite;

--- a/public/js/gl/orbit.js
+++ b/public/js/gl/orbit.js
@@ -76,7 +76,7 @@ export function displayOrbit(satellite) {
   );
 
   const orbitMaterial = new THREE.LineBasicMaterial({ color: 0x3cebf0 }); // Light blue for orbit
-  const dynamicLineMaterial = new THREE.LineBasicMaterial({ color: 0xff5733 }); // Orange for dynamic line
+  const dynamicLineMaterial = new THREE.LineBasicMaterial({ color: 0x3cebf0 }); // Light blue for dynamic line
 
   currentOrbitLine = new THREE.Line(orbitPathGeometry, orbitMaterial);
   currentSatelliteCenterLine = new THREE.Line(

--- a/public/js/ui/popup.js
+++ b/public/js/ui/popup.js
@@ -84,6 +84,12 @@ function closePopup() {
 function togglePopupSize(event) {
   event.stopPropagation();
   popupContainer.classList.toggle("h-[95%]"); // extend the height
+
+  if (popupContainer.classList.contains("h-[95%]")) {
+    popupContainer.classList.add("popup-container-extended");
+  } else {
+    popupContainer.classList.remove("popup-container-extended");
+  }
   arrowIcon.classList.toggle("rotate-180");
 }
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -379,7 +379,7 @@
           <div id="popup-skeleton" class="space-y-4 p-4 text-teal-300">
             <p class="loading-text">Loading</p>
           </div>
-          <div id="popup-content" class="hidden space-y-4 p-4 text-teal-300"></div>
+          <div id="popup-content" class="hidden space-y-2 p-4 text-teal-300"></div>
         </div>
 
         <div id="toggle-arrow" class="flex justify-center items-center absolute bottom-3 w-full cursor-pointer py-2"

--- a/views/satellite.ejs
+++ b/views/satellite.ejs
@@ -1,32 +1,52 @@
 <div class="flex justify-items-center items-center justify-between">
-  <h2 class="text-2xl"><%= name %></h2>
+  <h2 class="text-2xl">
+    <%= name %>
+  </h2>
   <p>(NoID: <%= satellite_id %>)</p>
 </div>
 <hr class="border-teal-300" />
 <p>
-  <strong>Speed: <span id="satellite_speed_visualizer">0.00km/h</span></strong>
+  <strong>Speed:</strong> <span id="satellite_speed_visualizer">0.00km/h</span>
 </p>
 <p>
-  <strong>Longitude: <span id="satellite_long_visualizer"></span></strong>
+  <strong>Longitude:</strong> <span id="satellite_long_visualizer"></span>
 </p>
 <p>
-  <strong>Latitude: <span id="satellite_lat_visualizer"></span></strong>
+  <strong>Latitude:</strong> <span id="satellite_lat_visualizer"></span>
 </p>
 <p>
-  <strong
-    >Height: <%= farthest_orbit_distance %> km (Farthest) / <%=
-    lowest_orbit_distance %> km (Lowest)</strong
-  >
+  <strong>Orbit distance:</strong>
+  <%= farthest_orbit_distance %> km (Farthest) / <%= lowest_orbit_distance %> km (Lowest)
 </p>
 <p>
-  <strong
-    >Coordinates: Inclination <%= inclination %>°, Revolution Time: <%=
-    revolution %> hours</strong
-  >
+  <strong>Inclination:</strong>
+  <%= inclination %>°
 </p>
-<p><strong>Launch Date: <%= launch_date %></strong></p>
-<p><strong>Launch Site: <%= launch_site %></strong></p>
-<p><strong>Owner: <%= owner %></strong></p>
-<p><strong>Status: <%= status %></strong></p>
-<p><strong>Object Type: <%= object_type %></strong></p>
-<p><strong>Description:</strong> <%= description %></p>
+<p>
+  <strong>Revolution Time:</strong>
+  <%= revolution %> hours
+</p>
+<p>
+  <strong>Launch Date:</strong>
+  <%= launch_date %>
+</p>
+<p>
+  <strong>Launch Site:</strong>
+  <%= launch_site %>
+</p>
+<p>
+  <strong>Owner:</strong>
+  <%= owner %>
+</p>
+<!-- <p>
+  <strong>Status:</strong>
+  <%= status %>
+</p>
+<p>
+  <strong>Object Type:</strong>
+  <%= object_type %>
+</p> -->
+<p>
+  <strong>Description:</strong>
+  <%= description %>
+</p>


### PR DESCRIPTION
I know this is very ugly... Basically solved a bug with another bug... So it needs to be fixed in the future. But now the content in the popup is scrollable when the description is very long (mostly an issue on laptop). The problem is that the close button and the border is also following when scrolling (see image). 

This PR:
* Content is scrollable when description is long
* Removed status and object type from info
* Data is not in bold font, so it´s easier to read
* Changed back the color on the line between satellite and earth to blue 

<img width="399" alt="Skärmavbild 2024-11-28 kl  21 19 31" src="https://github.com/user-attachments/assets/426c763e-38de-41a0-b83d-4f0845325bd9">